### PR TITLE
Improve scheduler resilience to pauses

### DIFF
--- a/pytocron/_runner.py
+++ b/pytocron/_runner.py
@@ -32,6 +32,8 @@ _ATTRIBUTE_STARTED = "_started"
 
 _HARD_KILL_TOLERANCE_SECONDS = 5
 
+_SLEEP_PRECISE_THRESHOLD_SECONDS = 10
+
 _SHELL_ARGV = ["bash", "-euc"]
 _SETSID_ARGV = ["setsid", "--wait"]
 
@@ -75,7 +77,7 @@ def _create_cronjob_argv(command: str, tolerated_runtime_seconds: int | None) ->
     return _SETSID_ARGV + timeout_argv + _SHELL_ARGV + [command]
 
 
-def _run_single_cron_job(  # noqa: C901
+def _run_single_cron_job(  # noqa: C901, PLR0912
     crontab_entry: CrontabEntry,
     *,
     pretend: bool,
@@ -102,8 +104,14 @@ def _run_single_cron_job(  # noqa: C901
             f" ({math.ceil(sleep_seconds)} seconds from now).",
         )
 
-        if sleep_seconds > 0:
-            time.sleep(sleep_seconds)
+        while True:
+            remaining = next_run_epoch - localtime_epoch()
+            if remaining <= 0:
+                break
+            if remaining <= _SLEEP_PRECISE_THRESHOLD_SECONDS:
+                time.sleep(remaining)
+                break
+            time.sleep(remaining / 2)
 
         if second_next_run_epoch is None:
             tolerated_runtime_seconds = None  # i.e. unlimited

--- a/pytocron/tests/test_runner.py
+++ b/pytocron/tests/test_runner.py
@@ -18,6 +18,7 @@ from .._crontab_parser import CrontabEntry, _frequency_seven
 from .._runner import (
     _ATTRIBUTE_STARTED,
     _HARD_KILL_TOLERANCE_SECONDS,
+    _SLEEP_PRECISE_THRESHOLD_SECONDS,
     _create_cronjob_argv,
     _notify_healthchecks_io,
     _PingingFailedError,
@@ -167,9 +168,13 @@ class RunSingleCronJobTest(TestCase):
         ):
             _run_single_cron_job(crontab_entry, pretend=False)
 
-        self.assertEqual(sleep_mock.call_count, 3)
-        for i in range(3):
-            self.assertGreaterEqual(sleep_mock.call_args_list[i].args[0], 1)
+        self.assertGreater(sleep_mock.call_count, 3)
+        for call in sleep_mock.call_args_list:
+            self.assertGreater(call.args[0], 0)
+        self.assertLessEqual(
+            sleep_mock.call_args_list[-1].args[0],
+            _SLEEP_PRECISE_THRESHOLD_SECONDS,
+        )
 
         self.assertEqual(notify_healthchecks_io_mock.call_count, 3)
         for i in range(3):
@@ -194,9 +199,13 @@ class RunSingleCronJobTest(TestCase):
         ):
             _run_single_cron_job(crontab_entry, pretend=False)
 
-        self.assertEqual(sleep_mock.call_count, 3)
-        for i in range(3):
-            self.assertGreaterEqual(sleep_mock.call_args_list[i].args[0], 1)
+        self.assertGreater(sleep_mock.call_count, 3)
+        for call in sleep_mock.call_args_list:
+            self.assertGreater(call.args[0], 0)
+        self.assertLessEqual(
+            sleep_mock.call_args_list[-1].args[0],
+            _SLEEP_PRECISE_THRESHOLD_SECONDS,
+        )
 
         self.assertEqual(notify_healthchecks_io_mock.call_count, 3)
         for i in range(3):


### PR DESCRIPTION
## Summary
- retry sleep with halving intervals until the next run is within 10 seconds
- adjust tests for the new sleep behaviour

This approach mitigates missed run times when containers or systems pause unexpectedly. By waking up more frequently for long delays, pytocron recalculates the remaining time and can react to clock jumps before the job executes.

## Testing
- `ruff check .`
- `ruff format .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytz' etc.)*
- `pre-commit run --files pytocron/_runner.py pytocron/tests/test_runner.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853d32c3ad883218252bb769fc574b5